### PR TITLE
修改AMD转CMD时对依赖声明的处理方式

### DIFF
--- a/cmdify.js
+++ b/cmdify.js
@@ -65,6 +65,7 @@ function getDefineAmd(context) {
     return index;
   }
 }
+
 function getDefineAndFactory(context) {
   if(context.hasVid('define')) {
     var define = context.getVid('define');
@@ -81,11 +82,18 @@ function getDefineAndFactory(context) {
           && factory.prev().prev().leaves()[0].name() == JsNode.ARRLTR) {
           deps = factory.prev().prev().leaves()[0];
         }
+        var moduleId = null;
+        if(factory.parent().leaves().length > 1
+            && factory.parent().first().name() === JsNode.PRMREXPR
+            && factory.parent().first().first().name() === JsNode.TOKEN ) {
+            moduleId = factory.parent().first();
+        }
         return {
           'define': define[i],
           'deps': deps,
           'factory': factory,
-          'context': context
+          'context': context,
+          'moduleId': moduleId
         };
       }
     }
@@ -100,9 +108,18 @@ function getDefineAndFactory(context) {
 }
 function getDefineDeps(defFact) {
   var res = {
+    'id':null,
     'array': null,
     'params': null
   };
+  if(defFact.moduleId){
+      var idNode = defFact.moduleId.first();
+      res.id = {
+          'start': idNode.token().sIndex(),
+          'end': defFact.moduleId.next().token().sIndex() + 1,
+          'source': idNode.token().content()
+      };
+  }
   //factory为函数时，将依赖改写为cmd形式的require
   if(defFact.factory.name() == JsNode.FNEXPR) {
     if(defFact.deps) {
@@ -180,9 +197,9 @@ exports.convert = function(code, tp) {
                 req += 'require(' + s + ');';
             });
         }
-        code = (defDeps.array ? (code.slice(0, defDeps.array.start)
-            + code.slice(defDeps.array.end, defDeps.params.start)
-          ) : code.slice(0, defDeps.params.start))
+
+        code = code.slice(0, (defDeps.id || defDeps.array || defDeps.params).start)
+          + (defDeps.array ? code.slice(defDeps.array.end, defDeps.params.start) : "")
           + 'require, exports, module' + code.slice(defDeps.params.end, defDeps.fnbody)
           + req
           + code.slice(defDeps.fnbody);

--- a/cmdify.js
+++ b/cmdify.js
@@ -172,13 +172,15 @@ exports.convert = function(code, tp) {
             req += 'var ' + d + ' = require(' + s + ');';
           }
         });
+        if(defDeps.array && defDeps.params.source.length < defDeps.array.source.length){
+            defDeps.array.source.slice(defDeps.params.source.length).forEach(function(s){
+                if(/^['"][^./]/.test(s)) {
+                    s = s.charAt(0) + './' + s.slice(1)
+                }
+                req += 'require(' + s + ');';
+            });
+        }
         code = (defDeps.array ? (code.slice(0, defDeps.array.start)
-            + code.slice(defDeps.array.start, defDeps.array.end).replace(/(["']).+?\1/g, function(s) {
-              if(/^['"][^./]/.test(s)) {
-                s = s.charAt(0) + './' + s.slice(1);
-              }
-              return s;
-            })
             + code.slice(defDeps.array.end, defDeps.params.start)
           ) : code.slice(0, defDeps.params.start))
           + 'require, exports, module' + code.slice(defDeps.params.end, defDeps.fnbody)

--- a/tests/cmd/jquery-1.8.3.js
+++ b/tests/cmd/jquery-1.8.3.js
@@ -9466,7 +9466,7 @@ window.jQuery = window.$ = jQuery;
 // Do this after creating the global so that if an AMD module wants to call
 // noConflict to hide this version of jQuery, it will work.
 if ( typeof define === "function"  ) {
-	define( "jquery", [], function (require, exports, module) { return jQuery; } );
+	define(  function (require, exports, module) { return jQuery; } );
 }
 
 })( window );

--- a/tests/test.js
+++ b/tests/test.js
@@ -291,11 +291,15 @@ describe('simple test', function() {
     });
     it('define factory in amd style', function() {
       var res = ranma.cmdify('define(["./a", "./b"], function(a, b) {})');
-      expect(res).to.eql('define(["./a", "./b"], function(require, exports, module) {var a = require("./a");var b = require("./b");})');
+      expect(res).to.eql('define( function(require, exports, module) {var a = require("./a");var b = require("./b");})');
+    });
+    it('define id and factory in amd style', function() {
+        var res = ranma.cmdify('define("moduleId", ["./a", "./b"], function(a, b) {})');
+        expect(res).to.eql('define( function(require, exports, module) {var a = require("./a");var b = require("./b");})');
     });
     it('define deps not compact to params', function() {
       var res = ranma.cmdify('~function(){define(["a", "b"], function f(a){})}()');
-      expect(res).to.eql('~function(){define(["./a", "./b"], function f(require, exports, module){var a = require("./a");})}()');
+      expect(res).to.eql('~function(){define( function f(require, exports, module){var a = require("./a");require("./b");})}()');
     });
     it('commonjs', function() {
       var res = ranma.cmdify('module.exports = a;');
@@ -459,6 +463,7 @@ describe('jslib test', function() {
     });
   });
   describe('jquery-1.8.3', function() {
+    this.timeout(10000);
     var s = fs.readFileSync(path.join(__dirname, './src/jquery-1.8.3.js'), { encoding: 'utf-8' });
     var type = ranma.type.analyse(s);
     it('type isCommonJS', function() {


### PR DESCRIPTION
对于AMD：

``` javascript
define(['a','b'],function(a){
...
});
```

原有的转换结果是：

``` javascript
define(['a','b'],function(require, exports, module){
    var a = require('a');
});
```

这里虽然不影响模块的加载，但对打包还是略有影响。
调整后的效果：

``` javascript
define(function(require, exports, module){
    var a = require('a');
    require('b');
});
```
